### PR TITLE
Add ability to edit an alias in EDITOR

### DIFF
--- a/cmd/brew-alias.rb
+++ b/cmd/brew-alias.rb
@@ -71,6 +71,13 @@ module Aliases
       script.unlink
       symlink.unlink
     end
+
+
+    def edit
+      odie "Cannot edit 'brew-#{name}': Does not exist" if which("brew-#{name}").nil?
+
+      exec_editor "#{BASE_DIR}/#{name.gsub(/\W/, "_")}"
+    end
   end
 
   class << self
@@ -105,13 +112,18 @@ module Aliases
       end
     end
 
+    def edit(name)
+      Alias.new(name).edit
+    end
+
     def help
       <<-EOS.undent
         Usage:
-          brew alias foo=bar  # set 'brew foo' as an alias for 'brew bar'
-          brew alias foo      # print the alias 'foo'
-          brew alias          # print all aliases
-          brew unalias foo    # remove the 'foo' alias
+          brew alias foo=bar     # set 'brew foo' as an alias for 'brew bar'
+          brew alias foo --edit  # open up alias 'foo'in EDITOR
+          brew alias foo         # print the alias 'foo'
+          brew alias             # print all aliases
+          brew unalias foo       # remove the 'foo' alias
       EOS
     end
 
@@ -130,10 +142,16 @@ module Aliases
         ARGV.each { |a| remove a }
       else
         case arg
+        when "--edit"
+          edit ARGV[1]
         when /.=./
           add(*arg.split("=", 2))
         when /./
-          show arg
+          if ARGV[1] == "--edit"
+            edit arg
+          else
+            show arg
+          end
         else
           show
         end

--- a/cmd/brew-alias.rb
+++ b/cmd/brew-alias.rb
@@ -16,7 +16,7 @@ module Aliases
       @name = name.strip
 
       unless command.nil?
-        if command.start_with? "!"
+        if command.start_with? "!","%"
           command = command[1..-1]
         else
           command = "brew #{command}"


### PR DESCRIPTION
This PR adds the `--edit` subcommand, which when given with an alias will open that alias in with EDITOR. It can be called either of the following ways:

```
brew alias foo --edit 
brew alias --edit foo
``` 

---
**Motivation:** Since `brew alias` actually creates shell scripts, I thought it might be nice to be able to easily edit those scripts in a forward-compatible manner. Going straight to an editor obviates the need to implement a bunch of other features like shell parameter expansion or debugging.