### PR TITLE
Fixed unitialized constant error

### DIFF
--- a/cmd/brew-alias.rb
+++ b/cmd/brew-alias.rb
@@ -17,7 +17,7 @@ require "pathname"
 require "extend/string"
 
 BASE_DIR = File.expand_path "~/.brew-aliases"
-RESERVED = HOMEBREW_INTERNAL_COMMAND_ALIASES.keys + \
+RESERVED = Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.keys + \
            Dir["#{HOMEBREW_LIBRARY_PATH}/cmd/*.rb"].map { |cmd| File.basename(cmd, ".rb") } + \
            %w[alias unalias]
 


### PR DESCRIPTION
Hi there. 
Calling `brew alias` without options resulted in error:
```
Error: uninitialized constant HOMEBREW_INTERNAL_COMMAND_ALIASES
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-aliases/cmd/brew-alias.rb:20:in `<top (required)>'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/usr/local/Homebrew/Library/Homebrew/utils.rb:82:in `require?'
/usr/local/Homebrew/Library/Homebrew/brew.rb:105:in `<main>'
```

This PR fixes it. Thanks.