### PR TITLE
Save in XDG_CONFIG_HOME

### DIFF
--- a/lib/alias.rb
+++ b/lib/alias.rb
@@ -6,7 +6,7 @@ module Homebrew
       def initialize(name, command = nil)
         @name = name.strip
 
-        command ||= if command.start_with? "!", "%"
+        command &&= if command.start_with? "!", "%"
           command[1..]
         else
           "brew #{command}"
@@ -21,7 +21,7 @@ module Homebrew
 
       def cmd_exists?
         path = which("brew-#{name}.rb") || which("brew-#{name}")
-        !path.nil? && path.realpath.parent.to_s != BASE_DIR
+        !path.nil? && path.realpath.parent != BASE_DIR
       end
 
       def script
@@ -33,7 +33,7 @@ module Homebrew
       end
 
       def valid_symlink?
-        symlink.realpath.parent.to_s == BASE_DIR
+        symlink.realpath.parent == BASE_DIR
       rescue NameError
         false
       end

--- a/lib/aliases.rb
+++ b/lib/aliases.rb
@@ -5,9 +5,11 @@ module Homebrew
     # Unix-Like systems store config in $HOME/.config whose location can be
     # overriden by the XDG_CONFIG_HOME environment variable. Unfortunately
     # Homebrew strictly filters environment variables in BuildEnvironment.
-    BASE_DIR = Pathname.new("~/.config/brew-aliases").expand_path
-    # Default to HOME to avoid creating .config in case XDG_CONFIG_HOME is set.
-    BASE_DIR = Pathname.new("~/.brew-aliases").expand_path unless BASE_DIR.directory?
+    BASE_DIR = begin
+      Pathname.new("~/.config/brew-aliases").realpath
+    rescue
+      Pathname.new("~/.brew-aliases").expand_path
+    end
     RESERVED = Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.keys + \
                Dir["#{HOMEBREW_LIBRARY_PATH}/cmd/*.rb"].map { |cmd| File.basename(cmd, ".rb") } + \
                %w[alias unalias]

--- a/lib/aliases.rb
+++ b/lib/aliases.rb
@@ -2,7 +2,12 @@ require_relative "alias"
 
 module Homebrew
   module Aliases
-    BASE_DIR = File.expand_path "~/.brew-aliases"
+    # Unix-Like systems store config in $HOME/.config whose location can be
+    # overriden by the XDG_CONFIG_HOME environment variable. Unfortunately
+    # Homebrew strictly filters environment variables in BuildEnvironment.
+    BASE_DIR = Pathname.new("~/.config/brew-aliases").expand_path
+    # Default to HOME to avoid creating .config in case XDG_CONFIG_HOME is set.
+    BASE_DIR = Pathname.new("~/.brew-aliases").expand_path unless BASE_DIR.directory?
     RESERVED = Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.keys + \
                Dir["#{HOMEBREW_LIBRARY_PATH}/cmd/*.rb"].map { |cmd| File.basename(cmd, ".rb") } + \
                %w[alias unalias]


### PR DESCRIPTION
Closes #23 and fixes #24 again. The command logic was inverted. I had also introduced a bug changing BASE_DIR to a Pathname.

One sticky point I noticed is it doesn't fail gracefully when symlinks are missing. The problematic use case would be restoring your dotfiles. Should there be a command to reset symlinks?