### PR TITLE
Replace the deprecated `max_named` and `min_named` methods with `named_args`

### DIFF
--- a/cmd/alias.rb
+++ b/cmd/alias.rb
@@ -16,7 +16,7 @@ module Homebrew
       switch "--edit",
              description: "Edit aliases in a text editor. Either one or all aliases may be opened at once." \
                         " If the given alias doesn't exist it'll be pre-populated with a template."
-      max_named 1
+      named_args(max: 1)
     end
   end
 

--- a/cmd/alias.rb
+++ b/cmd/alias.rb
@@ -8,9 +8,8 @@ module Homebrew
 
   def alias_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `alias` [<alias> ... | <alias>=<command>]
-
+      usage_banner "`alias` [<alias> ... | <alias>=<command>]"
+      description <<~EOS
         Show existing aliases. If no aliases are given, print the whole list.
       EOS
       switch "--edit",

--- a/cmd/alias.rb
+++ b/cmd/alias.rb
@@ -16,7 +16,7 @@ module Homebrew
       switch "--edit",
              description: "Edit aliases in a text editor. Either one or all aliases may be opened at once." \
                         " If the given alias doesn't exist it'll be pre-populated with a template."
-      named_args(max: 1)
+      named_args max: 1
     end
   end
 

--- a/cmd/unalias.rb
+++ b/cmd/unalias.rb
@@ -13,7 +13,7 @@ module Homebrew
 
         Remove aliases.
       EOS
-      named_args(min: 1)
+      named_args min: 1
     end
   end
 

--- a/cmd/unalias.rb
+++ b/cmd/unalias.rb
@@ -8,11 +8,10 @@ module Homebrew
 
   def unalias_args
     Homebrew::CLI::Parser.new do
-      usage_banner "`unalias` <alias> [<alias> ...]"
       description <<~EOS
         Remove aliases.
       EOS
-      named_args min: 1
+      named_args :alias, min: 1
     end
   end
 

--- a/cmd/unalias.rb
+++ b/cmd/unalias.rb
@@ -13,7 +13,7 @@ module Homebrew
 
         Remove aliases.
       EOS
-      min_named 1
+      named_args(min: 1)
     end
   end
 

--- a/cmd/unalias.rb
+++ b/cmd/unalias.rb
@@ -8,9 +8,8 @@ module Homebrew
 
   def unalias_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `unalias` <alias> [<alias> ...]
-
+      usage_banner "`unalias` <alias> [<alias> ...]"
+      description <<~EOS
         Remove aliases.
       EOS
       named_args min: 1


### PR DESCRIPTION
The methods `max_named` and `min_named` had been deprecated in [brew v3](https://github.com/Homebrew/brew/blob/3.0.0/Library/Homebrew/cli/parser.rb#L396-L405).

When I run `brew alias` it warns me:
> Warning: Calling `max_named` is deprecated! Use `named_args max:` instead.
> Please report this issue to the homebrew/aliases tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
>   /usr/local/Homebrew/Library/Taps/homebrew/homebrew-aliases/cmd/alias.rb:19