### PR TITLE
Follow `BASE_DIR` symlinks

### DIFF
--- a/lib/aliases.rb
+++ b/lib/aliases.rb
@@ -7,9 +7,11 @@ module Homebrew
     # Unix-Like systems store config in $HOME/.config whose location can be
     # overridden by the XDG_CONFIG_HOME environment variable. Unfortunately
     # Homebrew strictly filters environment variables in BuildEnvironment.
-    BASE_DIR = begin
-      path = Pathname.new("~/.config/brew-aliases").expand_path
-      path.exist? ? path : Pathname.new("~/.brew-aliases").expand_path
+    BASE_DIR = if (path = Pathname.new("~/.config/brew-aliases").expand_path).exist? ||
+                  (path = Pathname.new("~/.brew-aliases").expand_path).exist?
+      path.realpath
+    else
+      path
     end.freeze
     RESERVED = (Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.keys + \
                Dir["#{HOMEBREW_LIBRARY_PATH}/cmd/*.rb"].map { |cmd| File.basename(cmd, ".rb") } + \


### PR DESCRIPTION
Currently, if `BASE_DIR` is a symlink, the link is not followed and `BASE_DIR` remains `~/.config/brew-aliases` or `~/.brew-aliases` instead of whatever the directory that was linked there is. This causes problems with `unalias` because [`Alias#valid_symlink?`](https://github.com/Homebrew/homebrew-aliases/blob/d00e4adb736c06b2071359ff32b146cd2ec2ef64/lib/alias.rb#L37-L41) because the alias symlink is followed and will not match `BASE_DIR` whose link has not been followed.

To try this out, symlink a directory to on the base directory options, create an alias, and try to remove it.

This PR modifies the logic that chooses `BASE_DIR` so it follows the link if it exists.
