### PR TITLE
brew alias automatically re-symlinks missing aliases

### DIFF
--- a/cmd/alias.rb
+++ b/cmd/alias.rb
@@ -15,10 +15,7 @@ module Homebrew
       switch "--edit",
              description: "Edit aliases in a text editor. Either one or all aliases may be opened at once. " \
                           "If the given alias doesn't exist it'll be pre-populated with a template."
-      switch "--repair",
-             description: "Repairs aliases that are not loaded into the Homebrew environment."
       named_args max: 1
-      conflicts "--edit", "--repair"
     end
   end
 
@@ -35,12 +32,6 @@ module Homebrew
         Aliases.edit_all
       else
         Aliases.edit arg
-      end
-    elsif args.repair?
-      if arg.present?
-        Aliases.repair arg
-      else
-        Aliases.repair
       end
     elsif /.=./.match?(arg)
       Aliases.add(*split_arg)

--- a/cmd/alias.rb
+++ b/cmd/alias.rb
@@ -15,7 +15,10 @@ module Homebrew
       switch "--edit",
              description: "Edit aliases in a text editor. Either one or all aliases may be opened at once. " \
                           "If the given alias doesn't exist it'll be pre-populated with a template."
+      switch "--repair",
+             description: "Repairs aliases that are not loaded into the Homebrew environment."
       named_args max: 1
+      conflicts "--edit", "--repair"
     end
   end
 
@@ -32,6 +35,12 @@ module Homebrew
         Aliases.edit_all
       else
         Aliases.edit arg
+      end
+    elsif args.repair?
+      if arg.present?
+        Aliases.repair arg
+      else
+        Aliases.repair
       end
     elsif /.=./.match?(arg)
       Aliases.add(*split_arg)

--- a/lib/aliases.rb
+++ b/lib/aliases.rb
@@ -58,12 +58,8 @@ module Homebrew
     def show(*aliases)
       each(aliases) do |target, cmd|
         puts "brew alias #{target}='#{cmd}'"
-      end
-    end
-
-    def repair(*aliases)
-      each(aliases) do |target, cmd|
-        Alias.new(target, cmd).write override: true
+        existing_alias = Alias.new(target, cmd)
+        existing_alias.write override: true unless existing_alias.symlink.exist?
       end
     end
 


### PR DESCRIPTION
Allows aliases saved from a backup of `BASE_DIR` to be rewritten and symlinked into Homebrew install.