### PR TITLE
Fix shellcheck issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master
 
-    - run: brew style $GITHUB_REPOSITORY
+    - run: brew style "$GITHUB_REPOSITORY"
 
     - name: Run brew alias
       run: brew alias


### PR DESCRIPTION
`shellcheck` is reporting an SC2086](https://www.shellcheck.net/wiki/SC2086) ("Double quote to prevent globbing and word splitting") issue in the `tests.yml` workflow. This adds quotes around the related area to resolve the issue.

Related to https://github.com/Homebrew/brew/pull/17482