### PR TITLE
don't overwrite potentially user created scripts

### DIFF
--- a/lib/alias.rb
+++ b/lib/alias.rb
@@ -40,6 +40,11 @@ module Homebrew
         false
       end
 
+      def link
+        FileUtils.rm symlink if File.symlink? symlink
+        FileUtils.ln_s script, symlink
+      end
+
       def write(opts = {})
         odie "'#{name}' is a reserved command. Sorry." if reserved?
         odie "'brew #{name}' already exists. Sorry." if cmd_exists?
@@ -74,7 +79,7 @@ module Homebrew
           EOS
         end
         script.chmod 0744
-        FileUtils.ln_sf script, symlink
+        link
       end
 
       def remove

--- a/lib/aliases.rb
+++ b/lib/aliases.rb
@@ -37,8 +37,8 @@ module Homebrew
       Dir["#{BASE_DIR}/*"].each do |path|
         next if path.end_with? "~" # skip Emacs-like backup files
 
-        _, meta, *lines = File.readlines(path)
-        target = meta.chomp.delete_prefix("# alias: brew ")
+        _shebang, _meta, *lines = File.readlines(path)
+        target = File.basename(path)
         next if !only.empty? && only.exclude?(target)
 
         lines.reject! { |line| line.start_with?("#") || line =~ /^\s*$/ }

--- a/lib/aliases.rb
+++ b/lib/aliases.rb
@@ -59,7 +59,7 @@ module Homebrew
       each(aliases) do |target, cmd|
         puts "brew alias #{target}='#{cmd}'"
         existing_alias = Alias.new(target, cmd)
-        existing_alias.write override: true unless existing_alias.symlink.exist?
+        existing_alias.link unless existing_alias.symlink.exist?
       end
     end
 

--- a/lib/aliases.rb
+++ b/lib/aliases.rb
@@ -26,7 +26,9 @@ module Homebrew
     end
 
     def add(name, command)
-      Alias.new(name, command).write
+      new_alias = Alias.new(name, command)
+      odie "alias 'brew #{name}' already exists!" if new_alias.script.exist?
+      new_alias.write
     end
 
     def remove(name)


### PR DESCRIPTION
- only write scripts when they don't yet exist 
- when we need the script name, trust the file name, not the script header
- fixes #74
