### PR TITLE
cli: handle '--edit' with '='

### DIFF
--- a/cmd/alias.rb
+++ b/cmd/alias.rb
@@ -26,6 +26,9 @@ module Homebrew
         if args.edit?
           if arg.blank?
             Aliases.edit_all
+          elsif /.=./.match?(arg)
+            Aliases.add(*split_arg)
+            Aliases.edit(split_arg.first)
           else
             Aliases.edit arg
           end


### PR DESCRIPTION
Before:
```
~ % brew alias foo=bar --edit
Editing /Users/rrotter/.config/homebrew/aliases/foo_bar
```
After:
```
~ % brew alias foo=bar --edit
Editing /Users/rrotter/.config/homebrew/aliases/foo
```

Combined w/ #75, this will print an error if `foo` already exists.