### PR TITLE
cmd*: Enable Sorbet at `typed: strict` level

### DIFF
--- a/cmd/alias.rb
+++ b/cmd/alias.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -17,6 +18,7 @@ module Homebrew
         named_args max: 1
       end
 
+      sig { override.void }
       def run
         arg = args.named.first
         split_arg = arg.split("=", 2) if arg.present?

--- a/cmd/alias.rbi
+++ b/cmd/alias.rbi
@@ -1,0 +1,11 @@
+# typed: strict
+
+class Homebrew::Cmd::Alias
+  sig { returns(Homebrew::Cmd::Alias::Args) }
+  def args; end
+end
+
+class Homebrew::Cmd::Alias::Args < Homebrew::CLI::Args
+  sig { returns(T::Boolean) }
+  def edit?; end
+end

--- a/cmd/unalias.rb
+++ b/cmd/unalias.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -13,6 +14,7 @@ module Homebrew
         named_args :alias, min: 1
       end
 
+      sig { override.void }
       def run
         Aliases.init
         args.named.each { |a| Aliases.remove a }


### PR DESCRIPTION
- Part of https://github.com/Homebrew/brew/issues/17297.