### PR TITLE
lib/aliases: disallow aliases conflicting with dev cmds

### DIFF
--- a/lib/aliases.rb
+++ b/lib/aliases.rb
@@ -14,8 +14,9 @@ module Homebrew
       path
     end.freeze
     RESERVED = (
-      Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.keys +
-      Dir["#{HOMEBREW_LIBRARY_PATH}/cmd/*.rb"].map { |cmd| File.basename(cmd, ".rb") } +
+      Commands.internal_commands +
+      Commands.internal_developer_commands +
+      Commands.internal_commands_aliases +
       %w[alias unalias]
     ).freeze
 


### PR DESCRIPTION
We already disallow aliases that have the same name as a built-in command, but we should also disallow aliases that conflict with developer commands. They don't work since the internal commands take precedence:

```console
$ brew alias bottle=install
$ brew bottle hello
Error: Formula not installed or up-to-date: hello
```
